### PR TITLE
代码分支管理指南：去除不允许在主仓库新建开发分支的限制

### DIFF
--- a/src/pages/git-branch-guide.md
+++ b/src/pages/git-branch-guide.md
@@ -45,5 +45,3 @@ Tag: 对应每个发布版本的 tag。SDK 和应用程序的 tag 遵照 `<major
 ## 其他
 
 并不是每个 bug 都有专门发布 bugfix 版的必要，对于不紧急的 bug，可以在 `master` 里 fix 后随下一个版本发布。
-
-在一个官方 repo 下只应该有以上说的 branch 和 tag，在开发过程中使用到的 feature branch 等请都放在个人的 fork，一律通过向 `master` 发 pull request 的方式给官方 repo 提交代码。


### PR DESCRIPTION
即对于有仓库权限的核心开发者，应该允许在主仓库上创建分支进行日常开发，这是基于：

- 目前我们一些仓库、一些同事就是这样做的（例如 https://github.com/leancloud/docs/branches 、https://github.com/leancloud/leanengine-node-sdk/branches 、 https://github.com/leancloud/ChatKit-OC/branches ）。
- 一些第三方集成出于安全考虑，只会对主仓库上的分支进行处理（例如 docs 的 heroku 预览集成）。
- 私有仓库 fork 之后，其他同事默认是没有读取权限的，只能看到 PR，却不能拉取仓库，每次都要提醒对方添加权限。